### PR TITLE
タイムゾーンを Tokyo に設定した

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,7 @@ module AwesomeEvents
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'Tokyo'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]


### PR DESCRIPTION
## やったこと
- タイムゾーンを日本時間に設定した（デフォルトはUTCだった）

## 理由
- アプリケーション上で時間を扱うため
 - イベントを新規作成した時にDBに日本時間として登録したい