### PR TITLE
イベント登録機能の作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem 'omniauth-twitter'
 
 group :development, :test do
   gem 'rspec-rails'
+  gem 'factory_girl_rails'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,11 @@ GEM
     diff-lcs (1.2.5)
     erubis (2.7.0)
     execjs (2.7.0)
+    factory_girl (4.7.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.7.0)
+      factory_girl (~> 4.7.0)
+      railties (>= 3.0.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     hashie (3.4.4)
@@ -187,6 +192,7 @@ DEPENDENCIES
   byebug
   capybara
   coffee-rails (~> 4.1.0)
+  factory_girl_rails
   jbuilder (~> 2.0)
   jquery-rails
   omniauth

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,11 @@ class ApplicationController < ActionController::Base
 
   private
 
+  def currenst_user
+    return unless session[:user_id]
+    @current_user ||= User.find(session[:user_id])
+  end
+
   def logged_in?
     !!session[:user_id]
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,4 +10,9 @@ class ApplicationController < ActionController::Base
   def logged_in?
     !!session[:user_id]
   end
+
+  def authenticate
+    return if logged_in?
+    redirect_to root_path, alert: 'ログインしてください'
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def currenst_user
+  def current_user
     return unless session[:user_id]
     @current_user ||= User.find(session[:user_id])
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,3 +1,7 @@
 class EventsController < ApplicationController
   before_action :authenticate
+
+  def new
+    @event = currenst_user.created_events.build
+  end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,2 +1,3 @@
 class EventsController < ApplicationController
+  before_action :authenticate
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,4 +4,21 @@ class EventsController < ApplicationController
   def new
     @event = current_user.created_events.build
   end
+
+  def create
+    @event = current_user.created_events.build(event_params)
+    if @event.save
+      redirect_to @event, notice: '作成しました'
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def event_params
+    params.require(:event).permit(
+      :name, :place, :content, :start_time, :end_time
+    )
+  end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,6 +2,6 @@ class EventsController < ApplicationController
   before_action :authenticate
 
   def new
-    @event = currenst_user.created_events.build
+    @event = current_user.created_events.build
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,6 @@
 class Event < ActiveRecord::Base
+  belongs_to :owner, class_name: 'User'
+
   validates :name, length: { maximum: 50 }, presence: true
   validates :place, length: { maximum: 100 }, presence: true
   validates :content, length: { maximum: 2000 }, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ActiveRecord::Base
+  has_many :created_events, class_name: 'Event', foreign_key: :owner_id
+
   def self.find_or_create_from_auth_hash(auth_hash)
     provider = auth_hash[:provider]
     uid = auth_hash[:uid]

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,0 +1,43 @@
+<% now = Time.zone.now %>
+
+<div class="page-header">
+  <h1>イベント作成</h1>
+</div>
+
+<%= form_for(@event, class: 'form-horizonal', role: 'form') do |f| %>
+  <%  if @event.errors.any? %>
+    <div class="alert alert-danger">
+      <ul>
+        <% @event.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= f.label :name %>
+    <%= f.text_field :name, class: 'form-control' %>
+  </div>
+  <div class="form-group">
+    <%= f.label :place %>
+    <%= f.text_field :place, class: 'form-control' %>
+  </div>
+  <div class="form-group">
+    <%= f.label :start_time %>
+    <div>
+      <%= f.datetime_select :start_time, start_year: now.year, end_year: now.year + 1 %>
+    </div>
+  </div>
+  <div class="form-group">
+    <%= f.label :end_time %>
+    <div>
+      <%= f.datetime_select :end_time, start_year: now.year, end_year: now.year + 1 %>
+    </div>
+  </div>
+  <div class="form-group">
+    <%= f.label :content %>
+    <%= f.text_area :content, class: 'form-control', row: 10 %>
+  </div>
+  <%= f.submit '作成', class: 'btn btn-default', data: { disable_with: '作成中...' } %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,6 +37,11 @@
           <%= flash[:notice] %>
         </div>
       <% end %>
+      <% if flash[:alert] %>
+        <div class="alert alert-danger">
+          <%= flash[:alert] %>
+        </div>
+      <% end %>
       <%= yield %>
     </div>
   </body>

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -10,9 +10,12 @@ RSpec.describe EventsController, type: :controller do
 
 
     context 'ログインしているとき' do
-      it 'ok!が返される' do
+      before do
         session[:user_id] = 'test_user'
         get :index
+      end
+
+      it 'ok!が返される' do
         expect(response.body).to eq "ok!"
       end
     end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -28,4 +28,26 @@ RSpec.describe EventsController, type: :controller do
       end
     end
   end
+
+  describe 'GET #new' do
+    context 'ログインユーザがアクセスしたとき' do
+      before do
+        user = create :user
+        session[:user_id] = user.id
+        get :new
+      end
+
+      it 'ステータスコードとして200を返すこと' do
+        expect(response.status).to eq 200
+      end
+
+      it '@eventに、新規 Event オブジェクトが格納されていること' do
+        expect(assigns(:event)).to be_a_new(Event)
+      end
+
+      it 'new テンプレートを render していること' do
+        expect(response).to render_template :new
+      end
+    end
+  end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -50,4 +50,37 @@ RSpec.describe EventsController, type: :controller do
       end
     end
   end
+
+  describe 'POST #create' do
+    before do
+      user = create :user
+      session[:user_id] = user.id
+    end
+
+    context 'イベント作成が成功したとき' do
+      let(:event) { attributes_for(:event) }
+      subject { post :create, event: event }
+
+      it 'DB に新規イベントが格納されている' do
+        expect{ subject }.to change(Event, :count).by(1)
+      end
+
+      it 'DB に格納した新規イベント情報がフォームに入力した情報と合っている' do
+        subject
+        expect(assigns(:event).owner_id).to eq session[:user_id]
+        expect(assigns(:event).name).to eq event[:name]
+        expect(assigns(:event).place).to eq event[:place]
+        expect(assigns(:event).start_time).not_to be_nil
+        expect(assigns(:event).end_time).not_to be_nil
+        expect(assigns(:event).content).to eq event[:content]
+      end
+    end
+
+    context 'イベント作成が失敗したとき' do
+      it 'new テンプレートを render していること' do
+        post :create, event: attributes_for(:event, place: nil)
+        expect(response).to render_template :new
+      end
+    end
+  end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -61,8 +61,9 @@ RSpec.describe EventsController, type: :controller do
       let(:event) { attributes_for(:event) }
       subject { post :create, event: event }
 
-      it 'ステータスコードとして200を返すこと' do
-        expect(response.status).to eq 200
+      it '作成後、イベント詳細ページにリダイレクトする' do
+        subject
+        expect(response).to redirect_to event_path(id: assigns(:event).id)
       end
 
       it 'DB に新規イベントが格納されている' do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -61,6 +61,10 @@ RSpec.describe EventsController, type: :controller do
       let(:event) { attributes_for(:event) }
       subject { post :create, event: event }
 
+      it 'ステータスコードとして200を返すこと' do
+        expect(response.status).to eq 200
+      end
+
       it 'DB に新規イベントが格納されている' do
         expect{ subject }.to change(Event, :count).by(1)
       end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,5 +1,31 @@
 require 'rails_helper'
 
 RSpec.describe EventsController, type: :controller do
+  describe ':authenticate' do
+    controller do
+      def index
+        render :text => 'ok!'
+      end
+    end
 
+
+    context 'ログインしているとき' do
+      it 'ok!が返される' do
+        session[:user_id] = 'test_user'
+        get :index
+        expect(response.body).to eq "ok!"
+      end
+    end
+
+    context 'ログインしていないとき' do
+      before { get :index }
+      it 'root_path にリダイレクトする' do
+        expect(response).to redirect_to(root_path)
+      end
+
+      it '『ログインしてください』というアラートが出る' do
+        expect(flash[:alert]).to eq 'ログインしてください'
+      end
+    end
+  end
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :event do
+    
+  end
+end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,5 +1,10 @@
 FactoryGirl.define do
   factory :event do
-    
+    owner
+    sequence(:name) { |i| "イベント名#{i}" }
+    sequence(:place) { |i| "イベント開催場所#{i}" }
+    sequence(:content) { |i| "イベント本文#{i}" }
+    start_time { rand(1..30).days.from_now }
+    end_time { start_time + rand(1..30).hours }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :user do
+    
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,8 @@
 FactoryGirl.define do
-  factory :user do
-    
+  factory :user, aliases: [:owner] do
+    provider 'twitter'
+    sequence(:uid) { |i| "uid#{i}" }
+    sequence(:place) { |i| "nickname#{i}" }
+    sequence(:image_url) { |i| "http://example.com/image/#{i}.jpg" }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :user, aliases: [:owner] do
     provider 'twitter'
     sequence(:uid) { |i| "uid#{i}" }
-    sequence(:place) { |i| "nickname#{i}" }
+    sequence(:nickname) { |i| "nickname#{i}" }
     sequence(:image_url) { |i| "http://example.com/image/#{i}.jpg" }
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,4 +45,6 @@ RSpec.configure do |config|
   config.include(Shoulda::Matchers::ActiveRecord, type: :model)
 
   config.infer_base_class_for_anonymous_controllers = true
+
+  config.include FactoryGirl::Syntax::Methods
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,4 +43,6 @@ RSpec.configure do |config|
 
   config.include(Shoulda::Matchers::ActiveModel, type: :model)
   config.include(Shoulda::Matchers::ActiveRecord, type: :model)
+
+  config.infer_base_class_for_anonymous_controllers = true
 end


### PR DESCRIPTION
## やったこと
- [x] factory_girl のインストール
- [x] Event と User のfactory_girl の定義
- [x] コントローラのテスト作成
- [x] ログイン状態を管理する処理を作る
- [x] イベント登録用のフォームを作る

## 動作確認
- イベント登録フォーム（/events/new）から新規イベントを追加する
 - 全てのフォームを埋める
 - Start Time は End Time よりも前の時間
- 作成ボタンを押して詳細ページ（/events/:event_id）に遷移することを確認する
 - 現状では `show` アクションを用意していないので Rails 側で怒られる

## Gif

![register event](https://cloud.githubusercontent.com/assets/7896080/15732877/9f25bef6-28bb-11e6-9cad-3d95b1d62559.gif)

