### PR TITLE
イベント詳細ページを作成した

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,5 @@
 class EventsController < ApplicationController
-  before_action :authenticate
+  before_action :authenticate, except: :show
 
   def show
     begin

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,6 +1,14 @@
 class EventsController < ApplicationController
   before_action :authenticate
 
+  def show
+    begin
+      @event = Event.find(params[:id])
+    rescue => e
+      render text: 'nothing', status: 404
+    end
+  end
+
   def new
     @event = current_user.created_events.build
   end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,0 +1,41 @@
+<div class="page-header">
+  <h1>
+    <%= @event.name %>
+  </h1>
+</div>
+
+<div class="panel panel-default">
+  <div class="panel-heading">
+    主催者
+  </div>
+  <div class="panel-body">
+    <%= link_to("https://twitter.com/#{@event.owner.nickname}") do %>
+      <%= image_tag @event.owner.image_url %>
+      <%= "@#{@event.owner.nickname}" %>
+    <% end %>
+  </div>
+</div>
+<div class="panel panel-default">
+  <div class="panel-heading">
+    開催時間
+  </div>
+  <div class="panel-body">
+    <%= @event.start_time.strftime('%Y/%m/%d %H:%M') %> - <%= @event.end_time.strftime('%Y/%m/%d %H:%M') %>
+  </div>
+</div>
+<div class="panel panel-default">
+  <div class="panel-heading">
+    開催場所
+  </div>
+  <div class="panel-body">
+    <%= @event.place %>
+  </div>
+</div>
+<div class="panel panel-default">
+  <div class="panel-heading">
+    イベント内容
+  </div>
+  <div class="panel-body">
+    <%= @event.content %>
+  </div>
+</div>

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -32,6 +32,51 @@ RSpec.describe EventsController, type: :controller do
     end
   end
 
+  describe 'GET #show' do
+    before do
+      user  = create :user
+      session[:user_id] = user.id
+    end
+
+    let(:event) { create :event }
+
+    context '作成したイベントページに遷移したとき' do
+      before do
+        get :show, id: event.id
+      end
+
+      it 'ステータスコードとして200を返すこと' do
+        expect(response.status).to eq 200
+      end
+
+      it 'show テンプレートを render していること' do
+        expect(response).to render_template :show
+      end
+
+      it '@event がイベント情報を持っていること' do
+        expect(assigns[:event]).to eq event
+      end
+    end
+
+    context '作成していないイベントページに遷移したとき' do
+      before do
+        get :show, id: 0
+      end
+
+      it 'ステータスコードとして404を返すこと' do
+        expect(response.status).to eq 404
+      end
+
+      it 'nothingが返される' do
+        expect(response.body).to eq "nothing"
+      end
+
+      it '@event には何も入っていない' do
+        expect(assigns[:event]).to be_nil
+      end
+    end
+  end
+
   describe 'GET #new' do
     context 'ログインユーザがアクセスしたとき' do
       before do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -33,15 +33,22 @@ RSpec.describe EventsController, type: :controller do
   end
 
   describe 'GET #show' do
-    before do
-      user  = create :user
-      session[:user_id] = user.id
-    end
-
     let(:event) { create :event }
+
+    context 'ログインしていないとき' do
+      before do
+        get :show, id: event.id
+      end
+
+      it 'ログインしていなくても show ページを render する' do
+        expect(response).to render_template :show
+      end
+    end
 
     context '作成したイベントページに遷移したとき' do
       before do
+        user  = create :user
+        session[:user_id] = user.id
         get :show, id: event.id
       end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe EventsController, type: :controller do
         get :show, id: event.id
       end
 
-      it 'ログインしていなくても show ページを render する' do
+      it 'show テンプレートを render していること' do
         expect(response).to render_template :show
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,4 +47,6 @@ RSpec.configure do |config|
   config.infer_base_class_for_anonymous_controllers = true
 
   config.include FactoryGirl::Syntax::Methods
+
+  config.include Capybara::DSL
 end

--- a/spec/views/events/show.html.erb_spec.rb
+++ b/spec/views/events/show.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "events/show", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/events/show.html.erb_spec.rb
+++ b/spec/views/events/show.html.erb_spec.rb
@@ -1,5 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe "events/show", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context '存在するイベントページにアクセスしたとき' do
+    let(:event) { create :event }
+
+    before do
+      visit event_path(event.id)
+    end
+
+    it '@event の情報が表示されている' do
+      expect(page).to have_text(event.name)
+      expect(page).to have_text(event.owner.nickname)
+      expect(page).to have_text(event.start_time.strftime('%Y/%m/%d %H:%M'))
+      expect(page).to have_text(event.end_time.strftime('%Y/%m/%d %H:%M'))
+      expect(page).to have_text(event.place)
+      expect(page).to have_text(event.content)
+    end
+  end
+
+  context '存在しないイベントページにアクセスしたとき' do
+    before do
+      visit event_path(0)
+    end
+
+    it 'nothing と表示される' do
+      expect(page).to have_text('nothing')
+    end
+  end
 end


### PR DESCRIPTION
## やったこと
- [x] `Event#show` アクションを作成した
- [x] イベント詳細ページのERBを書いた
## 動作確認
- `events/new` でイベント作成後に `events/1` パスにアクセスし、イベント情報が正しく表示できているか
- ログインしていない状態でも見ることができるか
- 存在しないイベントページにアクセスしたとき、nothing と表示されているか

![2016-06-09 15 49 45](https://cloud.githubusercontent.com/assets/7896080/15921071/c6143954-2e59-11e6-863f-841a459e303c.png)
